### PR TITLE
Make ASSET_URL optional in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,10 @@ APP_DEBUG=false
 APP_TIMEZONE=UTC
 APP_PORT=8000
 APP_URL="http://localhost:${APP_PORT}"
-ASSET_URL="${APP_URL}"
 SELF_HOSTED=true
 REGISTRATION_ENABLED=true
+
+# ASSET_URL="http://localhost:8000" # (optional) webroot for static assets (css, js, images, etc)
 
 AI_CHAT_ENABLED=false
 OPENAI_API_KEY=
@@ -31,7 +32,6 @@ FACEBOOK_CLIENT_SECRET=
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
-
 
 DB_CONNECTION=mysql
 DB_HOST=investbrain-mysql


### PR DESCRIPTION
When the ASSET_URL is set, it will try loading static assets (JS, CSS, images, etc) from that URL. This was previously set to localhost by default, which caused issues when installing on a remote machine. 

Removing ASSET_URL resolves #7 by loading static assets using a relative URL. 

Leaving the ASSET_URL in the example env in case anyone needs to update that in future.