### PR TITLE
fix: support mariadb in sync:daily-change

### DIFF
--- a/app/Models/Holding.php
+++ b/app/Models/Holding.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 class Holding extends Model
@@ -252,11 +253,19 @@ class Holding extends Model
 
             $date_interval = "date(date, '+1 day')";
         } else {
+
+            // MySQL default
             $max_recursion_var_name = 'cte_max_recursion_depth';
-            $results = DB::select("SHOW VARIABLES LIKE '$max_recursion_var_name';");
-            if(count($results) == 0) {
-                $max_recursion_var_name = 'max_recursive_iterations'; // Must be mariadb
+
+            // Determine if running MySQL or MariaDB
+            $versionString = Arr::get(
+                DB::select('SELECT VERSION() as version;'),
+                '0.version', ''
+            );
+            if (stripos($versionString, 'MariaDB') !== false) {
+                $max_recursion_var_name = 'max_recursive_iterations'; // Must be MariaDB
             }
+
             DB::statement("SET $max_recursion_var_name=1000000;");
         }
 

--- a/app/Models/Holding.php
+++ b/app/Models/Holding.php
@@ -62,8 +62,8 @@ class Holding extends Model
         return $this->hasMany(Dividend::class, 'symbol', 'symbol')
             ->select(['dividends.symbol', 'dividends.date', 'dividends.dividend_amount'])
             ->selectRaw("SUM(
-                    CASE WHEN transaction_type = 'BUY' 
-                        AND transactions.symbol = dividends.symbol 
+                    CASE WHEN transaction_type = 'BUY'
+                        AND transactions.symbol = dividends.symbol
                         AND transactions.portfolio_id = '$this->portfolio_id'
                         AND date(dividends.date) >= date(transactions.date)
                     THEN transactions.quantity
@@ -71,22 +71,22 @@ class Holding extends Model
                 ) AS purchased")
             ->selectRaw("SUM(
                     CASE WHEN transaction_type = 'SELL'
-                        AND transactions.symbol = dividends.symbol 
-                        AND transactions.portfolio_id = '$this->portfolio_id' 
+                        AND transactions.symbol = dividends.symbol
+                        AND transactions.portfolio_id = '$this->portfolio_id'
                         AND date(dividends.date) >= date(transactions.date)
                     THEN transactions.quantity
                     ELSE 0 END
                 ) AS sold")
             ->selectRaw("SUM(
-                    (CASE WHEN transaction_type = 'BUY' 
-                        AND transactions.symbol = dividends.symbol 
+                    (CASE WHEN transaction_type = 'BUY'
+                        AND transactions.symbol = dividends.symbol
                         AND transactions.portfolio_id = '$this->portfolio_id'
-                        AND date(transactions.date) <= date(dividends.date) 
+                        AND date(transactions.date) <= date(dividends.date)
                         THEN transactions.quantity ELSE 0 END
-                    - CASE WHEN transaction_type = 'SELL' 
-                        AND transactions.symbol = dividends.symbol 
+                    - CASE WHEN transaction_type = 'SELL'
+                        AND transactions.symbol = dividends.symbol
                         AND transactions.portfolio_id = '$this->portfolio_id'
-                        AND date(transactions.date) <= date(dividends.date) 
+                        AND date(transactions.date) <= date(dividends.date)
                         THEN transactions.quantity ELSE 0 END)
                     * dividends.dividend_amount
                 ) AS total_received")
@@ -252,8 +252,12 @@ class Holding extends Model
 
             $date_interval = "date(date, '+1 day')";
         } else {
-
-            DB::statement('SET cte_max_recursion_depth=1000000;');
+            $max_recursion_var_name = 'cte_max_recursion_depth';
+            $results = DB::select("SHOW VARIABLES LIKE '$max_recursion_var_name';");
+            if(count($results) == 0) {
+                $max_recursion_var_name = 'max_recursive_iterations'; // Must be mariadb
+            }
+            DB::statement("SET $max_recursion_var_name=1000000;");
         }
 
         return DB::table(DB::raw("(
@@ -276,15 +280,15 @@ class Holding extends Model
                 COALESCE(SUM(CASE WHEN transactions.transaction_type = 'SELL' THEN transactions.quantity ELSE 0 END), 0), 3) AS `owned`
             "),
                 DB::raw("
-               COALESCE(CASE 
+               COALESCE(CASE
                     WHEN (
                         ROUND(
-                        COALESCE(SUM(CASE WHEN transactions.transaction_type = 'BUY' THEN transactions.quantity ELSE 0 END), 0) - 
+                        COALESCE(SUM(CASE WHEN transactions.transaction_type = 'BUY' THEN transactions.quantity ELSE 0 END), 0) -
                         COALESCE(SUM(CASE WHEN transactions.transaction_type = 'SELL' THEN transactions.quantity ELSE 0 END), 0), 3)
                     ) = 0 THEN 0
-                    ELSE SUM(CASE 
-                        WHEN transactions.transaction_type = 'BUY' THEN transactions.quantity * transactions.cost_basis 
-                        ELSE 0 
+                    ELSE SUM(CASE
+                        WHEN transactions.transaction_type = 'BUY' THEN transactions.quantity * transactions.cost_basis
+                        ELSE 0
                     END)
                 END, 0) AS cost_basis
             "),


### PR DESCRIPTION
This adds support for mariadb which uses the variable `max_recursive_iterations` instead of `cte_max_recursion_depth`.