### PR TITLE
Fix: do not gracefully fail when symbol not found

### DIFF
--- a/app/Interfaces/MarketData/AlphaVantageMarketData.php
+++ b/app/Interfaces/MarketData/AlphaVantageMarketData.php
@@ -145,7 +145,7 @@ class AlphaVantageMarketData implements MarketDataInterface
                 return [$date => new Ohlc([
                     'symbol' => $symbol,
                     'date' => $date,
-                    'close' => Arr::get($history, '4. close'),
+                    'close' => (float) Arr::get($history, '4. close'),
                 ])];
             });
     }


### PR DESCRIPTION
Will throw exception for failures, which enables fallback to kick in
