### PR TITLE
feat: add optional market sentiment overlay for holdings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ TWELVEDATA_API_SECRET=
 MARKET_DATA_REFRESH=30
 DAILY_CHANGE_TIME=
 
+# Optional Adanos market sentiment overlay for holdings and asset detail pages
+ADANOS_API_KEY=
+ADANOS_MARKET_SENTIMENT_REFRESH=360
+ADANOS_MARKET_SENTIMENT_DAYS=7
+ADANOS_MARKET_SENTIMENT_SOURCES=reddit,x,news,polymarket
+
 #### Advanced configurations ####
 ENABLED_LOGIN_PROVIDERS= 
 GITHUB_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ MARKET_DATA_PROVIDER=yahoo,alphavantage,custom_provider
 
 Feel free to submit a PR with any custom providers you create.
 
+### Optional market sentiment overlay
+
+Investbrain can also show an optional market sentiment summary for holdings and asset detail pages. This is a separate overlay and does **not** replace your configured market data provider.
+
+To enable it, set an Adanos API key:
+
+```bash
+ADANOS_API_KEY=your_api_key
+```
+
+Optional tuning:
+
+```bash
+ADANOS_MARKET_SENTIMENT_REFRESH=360
+ADANOS_MARKET_SENTIMENT_DAYS=7
+ADANOS_MARKET_SENTIMENT_SOURCES=reddit,x,news,polymarket
+```
+
+When `ADANOS_API_KEY` is not configured, Investbrain will skip all sentiment requests and the UI/API will continue to work without sentiment data.
+
 ## Import / Export
 
 Investbrain includes a convenient feature which allows you to maintain the portability of your portfolios and transaction data. 
@@ -145,6 +165,10 @@ There are several optional configurations available when installing using the re
 | ALPACA_API_SECRET | If using the Alpaca provider | `null` |
 | TWELVEDATA_API_SECRET | If using the Twelve Data provider | `null` |
 | MARKET_DATA_REFRESH | Cadence to refresh market data in minutes | 30 |
+| ADANOS_API_KEY | Enables the optional Adanos market sentiment overlay for holdings and asset detail pages | `null` |
+| ADANOS_MARKET_SENTIMENT_REFRESH | Cadence to refresh cached market sentiment snapshots in minutes | 360 |
+| ADANOS_MARKET_SENTIMENT_DAYS | Lookback window passed to Adanos sentiment requests | 7 |
+| ADANOS_MARKET_SENTIMENT_SOURCES | Comma-separated sentiment sources to request (`reddit,x,news,polymarket`) | `reddit,x,news,polymarket` |
 | APP_TIMEZONE | Timezone for the application, including daily change captures | UTC |
 | AI_CHAT_ENABLED | Whether to enable AI chat features | `false` |
 | CHAT_PROVIDER | Which chat provider to use (one of `openai`, `anthropic`, `gemini`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, `ollama`) | `openai` |
@@ -201,6 +225,7 @@ If you need more details on what the command does, you can take a look at the op
 | Command      | Description      |
 | ------------- | ------------- |
 | refresh:market-data | Refreshes market data with your configured market data provider. |
+| refresh:market-sentiment | Refreshes optional Adanos market sentiment snapshots for tracked holding symbols. |
 | refresh:dividend-data | Refreshes dividend data with your configured market data provider. Will also re-calculate your total dividends earned for each holding. |
 | refresh:split-data | Refreshes splits data with your configured market data provider. Will also create new transactions to account for any splits. |
 | refresh:currency-data | Grabs the latest daily currency exchange rate data and persists to the database. |

--- a/app/Console/Commands/RefreshMarketSentiment.php
+++ b/app/Console/Commands/RefreshMarketSentiment.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Holding;
+use App\Models\MarketSentiment;
+use Illuminate\Console\Command;
+
+class RefreshMarketSentiment extends Command
+{
+    protected $signature = 'refresh:market-sentiment
+                            {--force : Ignore refresh delay}
+                            {--user= : Limit refresh to user\'s holdings}';
+
+    protected $description = 'Refresh optional market sentiment snapshots from Adanos';
+
+    public function handle(): int
+    {
+        if (! MarketSentiment::enabled()) {
+            $this->line('Skipping market sentiment refresh because ADANOS_API_KEY is not configured.');
+
+            return self::SUCCESS;
+        }
+
+        $force = (bool) ($this->option('force') ?? false);
+
+        $holdings = Holding::where('quantity', '>', 0)
+            ->select(['symbol'])
+            ->distinct();
+
+        if ($this->option('user')) {
+            $holdings->myHoldings($this->option('user'));
+        }
+
+        foreach ($holdings->get() as $holding) {
+            $this->line('Refreshing sentiment '.$holding->symbol);
+
+            try {
+                MarketSentiment::getMarketSentiment($holding->symbol, $force);
+            } catch (\Throwable $e) {
+                $this->line('Could not refresh sentiment for '.$holding->symbol.' ('.$e->getMessage().')');
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/ApiControllers/HoldingController.php
+++ b/app/Http/ApiControllers/HoldingController.php
@@ -19,7 +19,7 @@ class HoldingController extends ApiController
 
         $filters->setQuery(Holding::query());
         $filters->setScopes(['myHoldings']);
-        $filters->setEagerRelations(['market_data', 'transactions']);
+        $filters->setEagerRelations(['market_data', 'market_sentiment', 'transactions']);
         $filters->setSearchableColumns(['symbol']);
 
         return HoldingResource::collection($filters->paginated());
@@ -31,6 +31,7 @@ class HoldingController extends ApiController
         Gate::authorize('readOnly', $portfolio);
 
         $holding = $portfolio->holdings()->symbol($symbol)->firstOrFail();
+        $holding->loadMarketSentiment();
 
         return HoldingResource::make($holding);
     }

--- a/app/Http/ApiControllers/MarketDataController.php
+++ b/app/Http/ApiControllers/MarketDataController.php
@@ -15,9 +15,11 @@ class MarketDataController extends ApiController
     {
 
         try {
+            $marketData = MarketData::getMarketData($symbol);
+            $marketData->loadMarketSentiment();
 
             return MarketDataResource::make(
-                MarketData::getMarketData($symbol)
+                $marketData
             );
         } catch (\Throwable $e) {
 

--- a/app/Http/Controllers/HoldingController.php
+++ b/app/Http/Controllers/HoldingController.php
@@ -17,6 +17,7 @@ class HoldingController extends Controller
     {
         $holding = Holding::with([
             'market_data',
+            'market_sentiment',
             'transactions' => function ($query) use ($symbol) {
                 $query->where('transactions.symbol', $symbol);
             },
@@ -24,6 +25,8 @@ class HoldingController extends Controller
         ->symbol($symbol)
         ->portfolio($portfolio->id)
         ->firstOrFail();
+
+        $holding->loadMarketSentiment();
 
         $formattedTransactions = $holding->getFormattedTransactions();
 

--- a/app/Http/Resources/HoldingResource.php
+++ b/app/Http/Resources/HoldingResource.php
@@ -31,6 +31,10 @@ class HoldingResource extends JsonResource
             'total_market_value' => $this->total_market_value,
             'market_gain_dollars' => $this->market_gain_dollars,
             'market_gain_percent' => $this->market_gain_percent,
+            'market_sentiment' => $this->when(
+                $this->relationLoaded('market_sentiment') && $this->market_sentiment !== null,
+                fn (): MarketSentimentResource => MarketSentimentResource::make($this->market_sentiment)
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/MarketDataResource.php
+++ b/app/Http/Resources/MarketDataResource.php
@@ -29,6 +29,10 @@ class MarketDataResource extends JsonResource
             'trailing_pe' => $this->trailing_pe,
             'forward_pe' => $this->forward_pe,
             'book_value' => $this->book_value,
+            'market_sentiment' => $this->when(
+                $this->relationLoaded('market_sentiment') && $this->market_sentiment !== null,
+                fn (): MarketSentimentResource => MarketSentimentResource::make($this->market_sentiment)
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/MarketSentimentResource.php
+++ b/app/Http/Resources/MarketSentimentResource.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MarketSentimentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'symbol' => $this->symbol,
+            'average_buzz' => $this->average_buzz,
+            'average_bullish_pct' => $this->average_bullish_pct,
+            'coverage' => $this->coverage,
+            'source_alignment' => $this->source_alignment,
+            'sources' => [
+                'reddit' => [
+                    'buzz' => $this->reddit_buzz,
+                    'bullish_pct' => $this->reddit_bullish_pct,
+                    'mentions' => $this->reddit_mentions,
+                ],
+                'x' => [
+                    'buzz' => $this->x_buzz,
+                    'bullish_pct' => $this->x_bullish_pct,
+                    'mentions' => $this->x_mentions,
+                ],
+                'news' => [
+                    'buzz' => $this->news_buzz,
+                    'bullish_pct' => $this->news_bullish_pct,
+                    'mentions' => $this->news_mentions,
+                ],
+                'polymarket' => [
+                    'buzz' => $this->polymarket_buzz,
+                    'bullish_pct' => $this->polymarket_bullish_pct,
+                    'trade_count' => $this->polymarket_trade_count,
+                ],
+            ],
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Holding.php
+++ b/app/Models/Holding.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Traits\HasMarketData;
+use App\Traits\HasMarketSentiment;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -18,6 +19,7 @@ class Holding extends Model
 {
     use HasFactory;
     use HasMarketData;
+    use HasMarketSentiment;
     use HasUuids;
 
     protected $fillable = [

--- a/app/Models/MarketData.php
+++ b/app/Models/MarketData.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Actions\CopyToBaseCurrency;
 use App\Casts\BaseCurrency;
 use App\Interfaces\MarketData\MarketDataInterface;
+use App\Traits\HasMarketSentiment;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Pipeline;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Pipeline;
 class MarketData extends Model
 {
     use HasFactory;
+    use HasMarketSentiment;
 
     protected $primaryKey = 'symbol';
 

--- a/app/Models/MarketSentiment.php
+++ b/app/Models/MarketSentiment.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\AdanosMarketSentimentService;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MarketSentiment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'market_sentiment';
+
+    protected $primaryKey = 'symbol';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'symbol',
+        'average_buzz',
+        'average_bullish_pct',
+        'coverage',
+        'source_alignment',
+        'reddit_buzz',
+        'reddit_bullish_pct',
+        'reddit_mentions',
+        'x_buzz',
+        'x_bullish_pct',
+        'x_mentions',
+        'news_buzz',
+        'news_bullish_pct',
+        'news_mentions',
+        'polymarket_buzz',
+        'polymarket_bullish_pct',
+        'polymarket_trade_count',
+        'payload',
+    ];
+
+    protected $casts = [
+        'average_buzz' => 'float',
+        'average_bullish_pct' => 'float',
+        'coverage' => 'integer',
+        'reddit_buzz' => 'float',
+        'reddit_bullish_pct' => 'integer',
+        'reddit_mentions' => 'integer',
+        'x_buzz' => 'float',
+        'x_bullish_pct' => 'integer',
+        'x_mentions' => 'integer',
+        'news_buzz' => 'float',
+        'news_bullish_pct' => 'integer',
+        'news_mentions' => 'integer',
+        'polymarket_buzz' => 'float',
+        'polymarket_bullish_pct' => 'integer',
+        'polymarket_trade_count' => 'integer',
+        'payload' => 'array',
+    ];
+
+    public function holdings()
+    {
+        return $this->hasMany(Holding::class, 'symbol', 'symbol');
+    }
+
+    public function scopeSymbol($query, string $symbol)
+    {
+        return $query->where('symbol', strtoupper($symbol));
+    }
+
+    public static function enabled(): bool
+    {
+        return app(AdanosMarketSentimentService::class)->enabled();
+    }
+
+    public static function getMarketSentiment(string $symbol, bool $force = false): ?self
+    {
+        if (! self::enabled()) {
+            return null;
+        }
+
+        $symbol = strtoupper(trim($symbol));
+
+        if ($symbol === '') {
+            return null;
+        }
+
+        $marketSentiment = self::firstOrNew([
+            'symbol' => $symbol,
+        ]);
+
+        if (
+            $force
+            || ! $marketSentiment->exists
+            || is_null($marketSentiment->updated_at)
+            || $marketSentiment->updated_at->diffInMinutes(now()) >= (int) config('services.adanos.market_sentiment_refresh', 360)
+        ) {
+            $payload = app(AdanosMarketSentimentService::class)->fetch($symbol);
+
+            if ($payload !== null) {
+                $marketSentiment->fill($payload);
+                $marketSentiment->save();
+            }
+        }
+
+        return $marketSentiment->exists ? $marketSentiment : null;
+    }
+}

--- a/app/Support/AdanosMarketSentimentService.php
+++ b/app/Support/AdanosMarketSentimentService.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+class AdanosMarketSentimentService
+{
+    private const BASE_URL = 'https://api.adanos.org';
+
+    private const SUPPORTED_SOURCES = [
+        'reddit',
+        'x',
+        'news',
+        'polymarket',
+    ];
+
+    public function enabled(): bool
+    {
+        return filled(config('services.adanos.key'));
+    }
+
+    public function fetch(string $symbol): ?array
+    {
+        if (! $this->enabled()) {
+            return null;
+        }
+
+        $ticker = strtoupper(trim($symbol));
+
+        if ($ticker === '') {
+            return null;
+        }
+
+        $payload = [];
+
+        foreach ($this->sources() as $source) {
+            $row = $this->fetchSourceRow($source, $ticker);
+
+            if ($row !== null) {
+                $payload[$source] = $row;
+            }
+        }
+
+        if ($payload === []) {
+            return null;
+        }
+
+        $availableRows = collect($payload);
+        $availableBuzz = $availableRows
+            ->pluck('buzz_score')
+            ->filter(static fn ($value) => $value !== null)
+            ->map(static fn ($value) => (float) $value)
+            ->values();
+        $availableBullish = $availableRows
+            ->pluck('bullish_pct')
+            ->filter(static fn ($value) => $value !== null)
+            ->map(static fn ($value) => (float) $value)
+            ->values();
+
+        return [
+            'symbol' => $ticker,
+            'average_buzz' => $availableBuzz->isNotEmpty() ? round($availableBuzz->avg(), 2) : null,
+            'average_bullish_pct' => $availableBullish->isNotEmpty() ? round($availableBullish->avg(), 2) : null,
+            'coverage' => $availableRows->count(),
+            'source_alignment' => $this->determineAlignment($availableBullish),
+            'reddit_buzz' => $this->numericValue(Arr::get($payload, 'reddit.buzz_score')),
+            'reddit_bullish_pct' => $this->integerValue(Arr::get($payload, 'reddit.bullish_pct')),
+            'reddit_mentions' => $this->integerValue(Arr::get($payload, 'reddit.mentions')),
+            'x_buzz' => $this->numericValue(Arr::get($payload, 'x.buzz_score')),
+            'x_bullish_pct' => $this->integerValue(Arr::get($payload, 'x.bullish_pct')),
+            'x_mentions' => $this->integerValue(Arr::get($payload, 'x.mentions')),
+            'news_buzz' => $this->numericValue(Arr::get($payload, 'news.buzz_score')),
+            'news_bullish_pct' => $this->integerValue(Arr::get($payload, 'news.bullish_pct')),
+            'news_mentions' => $this->integerValue(Arr::get($payload, 'news.mentions')),
+            'polymarket_buzz' => $this->numericValue(Arr::get($payload, 'polymarket.buzz_score')),
+            'polymarket_bullish_pct' => $this->integerValue(Arr::get($payload, 'polymarket.bullish_pct')),
+            'polymarket_trade_count' => $this->integerValue(Arr::get($payload, 'polymarket.trade_count')),
+            'payload' => $payload,
+        ];
+    }
+
+    protected function fetchSourceRow(string $source, string $symbol): ?array
+    {
+        $response = Http::acceptJson()
+            ->baseUrl(self::BASE_URL)
+            ->timeout(10)
+            ->withHeader('X-API-Key', (string) config('services.adanos.key'))
+            ->get(sprintf('/%s/stocks/v1/compare', $source), [
+                'tickers' => $symbol,
+                'days' => $this->days(),
+            ]);
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $stocks = $response->json('stocks');
+
+        if (! is_array($stocks) || $stocks === []) {
+            return null;
+        }
+
+        $row = collect($stocks)->first(function ($item) use ($symbol) {
+            return is_array($item) && strtoupper((string) Arr::get($item, 'ticker')) === $symbol;
+        });
+
+        if (! is_array($row)) {
+            $row = is_array($stocks[0] ?? null) ? $stocks[0] : null;
+        }
+
+        return is_array($row) ? $row : null;
+    }
+
+    protected function determineAlignment(Collection $bullishValues): string
+    {
+        if ($bullishValues->isEmpty()) {
+            return 'unavailable';
+        }
+
+        if ($bullishValues->count() === 1) {
+            return 'single-source';
+        }
+
+        $spread = $bullishValues->max() - $bullishValues->min();
+
+        if ($spread <= 15) {
+            return 'aligned';
+        }
+
+        if ($spread <= 35) {
+            return 'mixed';
+        }
+
+        return 'divergent';
+    }
+
+    protected function numericValue(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return round((float) $value, 2);
+    }
+
+    protected function integerValue(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) round((float) $value);
+    }
+
+    protected function days(): int
+    {
+        return max(1, min(30, (int) config('services.adanos.market_sentiment_days', 7)));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function sources(): array
+    {
+        $configured = array_filter(array_map('trim', explode(',', (string) config('services.adanos.market_sentiment_sources', 'reddit,x,news,polymarket'))));
+        $filtered = array_values(array_intersect(self::SUPPORTED_SOURCES, $configured));
+
+        return $filtered !== [] ? $filtered : self::SUPPORTED_SOURCES;
+    }
+}

--- a/app/Traits/HasMarketSentiment.php
+++ b/app/Traits/HasMarketSentiment.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Models\MarketSentiment;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+trait HasMarketSentiment
+{
+    public function market_sentiment(): HasOne
+    {
+        return $this->hasOne(MarketSentiment::class, 'symbol', 'symbol');
+    }
+
+    public function loadMarketSentiment(bool $force = false): void
+    {
+        if (! MarketSentiment::enabled()) {
+            return;
+        }
+
+        $symbol = (string) $this->getAttribute('symbol');
+
+        if ($symbol === '') {
+            return;
+        }
+
+        $this->setRelation('market_sentiment', MarketSentiment::getMarketSentiment($symbol, $force));
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -30,6 +30,14 @@ return [
         'key' => env('RESEND_KEY'),
     ],
 
+    'adanos' => [
+        'key' => env('ADANOS_API_KEY'),
+        'base_url' => 'https://api.adanos.org',
+        'market_sentiment_refresh' => (int) env('ADANOS_MARKET_SENTIMENT_REFRESH', 360),
+        'market_sentiment_days' => (int) env('ADANOS_MARKET_SENTIMENT_DAYS', 7),
+        'market_sentiment_sources' => env('ADANOS_MARKET_SENTIMENT_SOURCES', 'reddit,x,news,polymarket'),
+    ],
+
     'slack' => [
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),

--- a/database/migrations/2026_04_07_000001_create_market_sentiment_table.php
+++ b/database/migrations/2026_04_07_000001_create_market_sentiment_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('market_sentiment', function (Blueprint $table) {
+            $table->string('symbol', 25)->primary();
+            $table->float('average_buzz', 8, 2)->nullable();
+            $table->float('average_bullish_pct', 8, 2)->nullable();
+            $table->unsignedTinyInteger('coverage')->default(0);
+            $table->string('source_alignment', 25)->nullable();
+
+            $table->float('reddit_buzz', 8, 2)->nullable();
+            $table->unsignedTinyInteger('reddit_bullish_pct')->nullable();
+            $table->unsignedInteger('reddit_mentions')->nullable();
+
+            $table->float('x_buzz', 8, 2)->nullable();
+            $table->unsignedTinyInteger('x_bullish_pct')->nullable();
+            $table->unsignedInteger('x_mentions')->nullable();
+
+            $table->float('news_buzz', 8, 2)->nullable();
+            $table->unsignedTinyInteger('news_bullish_pct')->nullable();
+            $table->unsignedInteger('news_mentions')->nullable();
+
+            $table->float('polymarket_buzz', 8, 2)->nullable();
+            $table->unsignedTinyInteger('polymarket_bullish_pct')->nullable();
+            $table->unsignedInteger('polymarket_trade_count')->nullable();
+
+            $table->json('payload')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('market_sentiment');
+    }
+};

--- a/resources/views/holding/show.blade.php
+++ b/resources/views/holding/show.blade.php
@@ -1,4 +1,5 @@
 @use('App\Models\Currency')
+@use('Illuminate\Support\Number')
 
 <x-layouts.app>
     <div x-data>  
@@ -121,6 +122,79 @@
                 @endif
                 
             </x-ui.card>
+
+            @if(config('services.adanos.key'))
+            <x-ui.card title="{{ __('Market sentiment') }}" class="md:col-span-4">
+                @if($holding->market_sentiment)
+                <div class="space-y-3 text-sm">
+                    <div class="grid grid-cols-2 gap-3">
+                        <div>
+                            <div class="text-secondary">{{ __('Buzz') }}</div>
+                            <div class="font-semibold">{{ Number::format($holding->market_sentiment->average_buzz ?? 0, precision: 1) }}/100</div>
+                        </div>
+                        <div>
+                            <div class="text-secondary">{{ __('Bullish') }}</div>
+                            <div class="font-semibold">{{ Number::percentage(($holding->market_sentiment->average_bullish_pct ?? 0) / 100, 0) }}</div>
+                        </div>
+                        <div>
+                            <div class="text-secondary">{{ __('Coverage') }}</div>
+                            <div class="font-semibold">{{ $holding->market_sentiment->coverage }} {{ __('sources') }}</div>
+                        </div>
+                        <div>
+                            <div class="text-secondary">{{ __('Alignment') }}</div>
+                            <div class="font-semibold">{{ str($holding->market_sentiment->source_alignment)->replace('-', ' ')->title() }}</div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-2 border-t pt-3">
+                        @if(!is_null($holding->market_sentiment->reddit_buzz))
+                        <p>
+                            <span class="font-bold">Reddit:</span>
+                            {{ __('Buzz') }} {{ Number::format($holding->market_sentiment->reddit_buzz, precision: 1) }},
+                            {{ __('Bullish') }} {{ Number::percentage(($holding->market_sentiment->reddit_bullish_pct ?? 0) / 100, 0) }},
+                            {{ __('Mentions') }} {{ Number::format($holding->market_sentiment->reddit_mentions ?? 0) }}
+                        </p>
+                        @endif
+
+                        @if(!is_null($holding->market_sentiment->x_buzz))
+                        <p>
+                            <span class="font-bold">X:</span>
+                            {{ __('Buzz') }} {{ Number::format($holding->market_sentiment->x_buzz, precision: 1) }},
+                            {{ __('Bullish') }} {{ Number::percentage(($holding->market_sentiment->x_bullish_pct ?? 0) / 100, 0) }},
+                            {{ __('Mentions') }} {{ Number::format($holding->market_sentiment->x_mentions ?? 0) }}
+                        </p>
+                        @endif
+
+                        @if(!is_null($holding->market_sentiment->news_buzz))
+                        <p>
+                            <span class="font-bold">{{ __('Finance News') }}:</span>
+                            {{ __('Buzz') }} {{ Number::format($holding->market_sentiment->news_buzz, precision: 1) }},
+                            {{ __('Bullish') }} {{ Number::percentage(($holding->market_sentiment->news_bullish_pct ?? 0) / 100, 0) }},
+                            {{ __('Mentions') }} {{ Number::format($holding->market_sentiment->news_mentions ?? 0) }}
+                        </p>
+                        @endif
+
+                        @if(!is_null($holding->market_sentiment->polymarket_buzz))
+                        <p>
+                            <span class="font-bold">Polymarket:</span>
+                            {{ __('Buzz') }} {{ Number::format($holding->market_sentiment->polymarket_buzz, precision: 1) }},
+                            {{ __('Bullish') }} {{ Number::percentage(($holding->market_sentiment->polymarket_bullish_pct ?? 0) / 100, 0) }},
+                            {{ __('Trades') }} {{ Number::format($holding->market_sentiment->polymarket_trade_count ?? 0) }}
+                        </p>
+                        @endif
+                    </div>
+
+                    <p class="text-xs text-secondary">
+                        {{ __('Updated :time', ['time' => $holding->market_sentiment->updated_at?->diffForHumans()]) }}
+                    </p>
+                </div>
+                @else
+                <div class="flex justify-center items-center h-full pb-10 text-secondary">
+                    {{ __('No market sentiment is available for :symbol right now.', ['symbol' => $holding->symbol]) }}
+                </div>
+                @endif
+            </x-ui.card>
+            @endif
 
             <x-ui.card title="{{ __('Recent activity') }}" class="md:col-span-3">
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,6 +6,7 @@ use App\Console\Commands\CaptureDailyChange;
 use App\Console\Commands\RefreshCurrencyData;
 use App\Console\Commands\RefreshDividendData;
 use App\Console\Commands\RefreshMarketData;
+use App\Console\Commands\RefreshMarketSentiment;
 use App\Console\Commands\RefreshSplitData;
 use App\Console\Commands\SyncHoldingData;
 use Illuminate\Support\Facades\Schedule;
@@ -15,6 +16,13 @@ use Illuminate\Support\Facades\Schedule;
  * Note: Update the cadence with the MARKET_DATA_REFRESH key in your env file (default: 30 minutes)
  */
 Schedule::command(RefreshMarketData::class)->weekdays()->everyMinute();
+
+/**
+ * Refreshes optional Adanos market sentiment snapshots for tracked holdings
+ */
+Schedule::command(RefreshMarketSentiment::class)
+    ->everySixHours()
+    ->when(fn () => filled(config('services.adanos.key')));
 
 /**
  * This scheduled job records daily changes to your portfolios every weekday

--- a/tests/Api/HoldingsTest.php
+++ b/tests/Api/HoldingsTest.php
@@ -9,6 +9,7 @@ use App\Models\Portfolio;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class HoldingsTest extends TestCase
@@ -115,5 +116,76 @@ class HoldingsTest extends TestCase
         $this->actingAs($otherUser)
             ->putJson(route('api.holding.update', ['portfolio' => $transaction->portfolio_id, 'symbol' => $transaction->symbol]), $data)
             ->assertForbidden();
+    }
+
+    public function test_holding_show_can_include_optional_market_sentiment()
+    {
+        config()->set('services.adanos.key', 'test-key');
+
+        Http::fake([
+            'https://api.adanos.org/reddit/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 55.4,
+                    'bullish_pct' => 62,
+                    'mentions' => 120,
+                ]],
+            ]),
+            'https://api.adanos.org/x/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 60.0,
+                    'bullish_pct' => 58,
+                    'mentions' => 94,
+                ]],
+            ]),
+            'https://api.adanos.org/news/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 48.0,
+                    'bullish_pct' => 61,
+                    'mentions' => 37,
+                ]],
+            ]),
+            'https://api.adanos.org/polymarket/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 50.0,
+                    'bullish_pct' => 64,
+                    'trade_count' => 512,
+                ]],
+            ]),
+        ]);
+
+        $this->actingAs($this->user);
+
+        $transaction = Transaction::factory()
+            ->buy()
+            ->symbol('AAPL')
+            ->create();
+
+        $this->getJson(route('api.holding.show', ['portfolio' => $transaction->portfolio_id, 'symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertJsonPath('market_sentiment.average_buzz', 53.35)
+            ->assertJsonPath('market_sentiment.source_alignment', 'aligned')
+            ->assertJsonPath('market_sentiment.sources.news.mentions', 37);
+    }
+
+    public function test_holding_show_omits_market_sentiment_when_adanos_is_not_configured()
+    {
+        Http::fake();
+
+        $this->actingAs($this->user);
+
+        $transaction = Transaction::factory()
+            ->buy()
+            ->symbol('AAPL')
+            ->create();
+
+        $this->getJson(route('api.holding.show', ['portfolio' => $transaction->portfolio_id, 'symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertJsonMissingPath('market_sentiment');
+
+        Http::assertNothingSent();
     }
 }

--- a/tests/Api/MarketDataTest.php
+++ b/tests/Api/MarketDataTest.php
@@ -7,6 +7,7 @@ namespace Tests\Api;
 use App\Models\MarketData;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class MarketDataTest extends TestCase
@@ -71,5 +72,71 @@ class MarketDataTest extends TestCase
     public function test_cannot_access_market_data_when_unauthenticated(): void
     {
         $this->getJson(route('api.market-data.show', ['symbol' => 'AAPL']))->assertUnauthorized();
+    }
+
+    public function test_market_data_can_include_optional_market_sentiment(): void
+    {
+        config()->set('services.adanos.key', 'test-key');
+
+        MarketData::getMarketData('AAPL');
+
+        Http::fake([
+            'https://api.adanos.org/reddit/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 55.4,
+                    'bullish_pct' => 62,
+                    'mentions' => 120,
+                ]],
+            ]),
+            'https://api.adanos.org/x/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 60.0,
+                    'bullish_pct' => 58,
+                    'mentions' => 94,
+                ]],
+            ]),
+            'https://api.adanos.org/news/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 48.0,
+                    'bullish_pct' => 61,
+                    'mentions' => 37,
+                ]],
+            ]),
+            'https://api.adanos.org/polymarket/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 50.0,
+                    'bullish_pct' => 64,
+                    'trade_count' => 512,
+                ]],
+            ]),
+        ]);
+
+        $this->actingAs($this->user)
+            ->getJson(route('api.market-data.show', ['symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertJsonPath('market_sentiment.average_buzz', 53.35)
+            ->assertJsonPath('market_sentiment.average_bullish_pct', 61.25)
+            ->assertJsonPath('market_sentiment.coverage', 4)
+            ->assertJsonPath('market_sentiment.source_alignment', 'aligned')
+            ->assertJsonPath('market_sentiment.sources.reddit.mentions', 120)
+            ->assertJsonPath('market_sentiment.sources.polymarket.trade_count', 512);
+    }
+
+    public function test_market_data_omits_market_sentiment_when_adanos_is_not_configured(): void
+    {
+        MarketData::getMarketData('AAPL');
+
+        Http::fake();
+
+        $this->actingAs($this->user)
+            ->getJson(route('api.market-data.show', ['symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertJsonMissingPath('market_sentiment');
+
+        Http::assertNothingSent();
     }
 }

--- a/tests/HoldingsTest.php
+++ b/tests/HoldingsTest.php
@@ -9,6 +9,7 @@ use App\Models\Portfolio;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 
 class HoldingsTest extends TestCase
 {
@@ -73,5 +74,88 @@ class HoldingsTest extends TestCase
         $transaction->delete();
 
         $this->assertDatabaseEmpty('holdings');
+    }
+
+    public function test_holding_page_can_render_optional_market_sentiment_card(): void
+    {
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        config()->set('services.adanos.key', 'test-key');
+
+        Http::fake([
+            'https://api.adanos.org/reddit/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 55.4,
+                    'bullish_pct' => 62,
+                    'mentions' => 120,
+                ]],
+            ]),
+            'https://api.adanos.org/x/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 60.0,
+                    'bullish_pct' => 58,
+                    'mentions' => 94,
+                ]],
+            ]),
+            'https://api.adanos.org/news/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 48.0,
+                    'bullish_pct' => 61,
+                    'mentions' => 37,
+                ]],
+            ]),
+            'https://api.adanos.org/polymarket/stocks/v1/compare*' => Http::response([
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 50.0,
+                    'bullish_pct' => 64,
+                    'trade_count' => 512,
+                ]],
+            ]),
+        ]);
+
+        $this->actingAs($user = User::factory()->create());
+
+        $portfolio = Portfolio::factory()->create();
+
+        Transaction::factory()
+            ->buy()
+            ->lastYear()
+            ->portfolio($portfolio->id)
+            ->symbol('AAPL')
+            ->create();
+
+        $this->get(route('holding.show', ['portfolio' => $portfolio->id, 'symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertSee('Market sentiment')
+            ->assertSee('Reddit:')
+            ->assertSee('Finance News')
+            ->assertSee('Polymarket:');
+    }
+
+    public function test_holding_page_hides_market_sentiment_when_adanos_is_not_configured(): void
+    {
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+
+        Http::fake();
+
+        $this->actingAs($user = User::factory()->create());
+
+        $portfolio = Portfolio::factory()->create();
+
+        Transaction::factory()
+            ->buy()
+            ->lastYear()
+            ->portfolio($portfolio->id)
+            ->symbol('AAPL')
+            ->create();
+
+        $this->get(route('holding.show', ['portfolio' => $portfolio->id, 'symbol' => 'AAPL']))
+            ->assertOk()
+            ->assertDontSee('Market sentiment');
+
+        Http::assertNothingSent();
     }
 }

--- a/tests/MarketSentimentTest.php
+++ b/tests/MarketSentimentTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Models\MarketSentiment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+class MarketSentimentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_market_sentiment_is_disabled_without_api_key(): void
+    {
+        config()->set('services.adanos.key', null);
+
+        Http::fake();
+
+        $result = MarketSentiment::getMarketSentiment('AAPL');
+
+        $this->assertNull($result);
+        Http::assertNothingSent();
+    }
+
+    public function test_market_sentiment_fetches_and_persists_source_metrics(): void
+    {
+        config()->set('services.adanos.key', 'test-key');
+
+        Http::fake($this->fakeSentimentResponses());
+
+        $sentiment = MarketSentiment::getMarketSentiment('AAPL');
+
+        $this->assertNotNull($sentiment);
+        $this->assertSame('AAPL', $sentiment->symbol);
+        $this->assertSame(4, $sentiment->coverage);
+        $this->assertSame('aligned', $sentiment->source_alignment);
+        $this->assertEquals(53.35, $sentiment->average_buzz);
+        $this->assertEquals(61.25, $sentiment->average_bullish_pct);
+        $this->assertSame(120, $sentiment->reddit_mentions);
+        $this->assertSame(94, $sentiment->x_mentions);
+        $this->assertSame(37, $sentiment->news_mentions);
+        $this->assertSame(512, $sentiment->polymarket_trade_count);
+
+        $this->assertDatabaseHas('market_sentiment', [
+            'symbol' => 'AAPL',
+            'coverage' => 4,
+            'source_alignment' => 'aligned',
+        ]);
+
+        Http::assertSentCount(4);
+    }
+
+    public function test_market_sentiment_uses_database_cache_until_refresh_window_expires(): void
+    {
+        config()->set('services.adanos.key', 'test-key');
+        config()->set('services.adanos.market_sentiment_refresh', 360);
+
+        Http::fake($this->fakeSentimentResponses());
+
+        $first = MarketSentiment::getMarketSentiment('AAPL');
+        $second = MarketSentiment::getMarketSentiment('AAPL');
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertTrue($first->is($second));
+
+        Http::assertSentCount(4);
+    }
+
+    /**
+     * @return array<string, \Illuminate\Http\Client\Response>
+     */
+    protected function fakeSentimentResponses(): array
+    {
+        return [
+            'https://api.adanos.org/reddit/stocks/v1/compare*' => Http::response([
+                'period_days' => 7,
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 55.4,
+                    'bullish_pct' => 62,
+                    'mentions' => 120,
+                ]],
+            ]),
+            'https://api.adanos.org/x/stocks/v1/compare*' => Http::response([
+                'period_days' => 7,
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 60.0,
+                    'bullish_pct' => 58,
+                    'mentions' => 94,
+                ]],
+            ]),
+            'https://api.adanos.org/news/stocks/v1/compare*' => Http::response([
+                'period_days' => 7,
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 48.0,
+                    'bullish_pct' => 61,
+                    'mentions' => 37,
+                ]],
+            ]),
+            'https://api.adanos.org/polymarket/stocks/v1/compare*' => Http::response([
+                'period_days' => 7,
+                'stocks' => [[
+                    'ticker' => 'AAPL',
+                    'buzz_score' => 50.0,
+                    'bullish_pct' => 64,
+                    'trade_count' => 512,
+                ]],
+            ]),
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,17 +8,68 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
+    private bool $createdViteManifest = false;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        //
+        $this->ensureViteManifest();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        $this->cleanupViteManifest();
 
-        //
+        parent::tearDown();
+    }
+
+    private function ensureViteManifest(): void
+    {
+        $manifestPath = public_path('build/manifest.json');
+
+        if (is_file($manifestPath)) {
+            return;
+        }
+
+        $buildDirectory = dirname($manifestPath);
+
+        if (! is_dir($buildDirectory)) {
+            mkdir($buildDirectory, 0777, true);
+        }
+
+        file_put_contents($manifestPath, json_encode([
+            'resources/css/app.css' => [
+                'file' => 'assets/app.css',
+                'src' => 'resources/css/app.css',
+                'isEntry' => true,
+            ],
+            'resources/js/app.js' => [
+                'file' => 'assets/app.js',
+                'src' => 'resources/js/app.js',
+                'isEntry' => true,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        $this->createdViteManifest = true;
+    }
+
+    private function cleanupViteManifest(): void
+    {
+        if (! $this->createdViteManifest) {
+            return;
+        }
+
+        $manifestPath = public_path('build/manifest.json');
+
+        if (is_file($manifestPath)) {
+            unlink($manifestPath);
+        }
+
+        $buildDirectory = dirname($manifestPath);
+
+        if (is_dir($buildDirectory) && count(scandir($buildDirectory)) === 2) {
+            rmdir($buildDirectory);
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds an optional market sentiment overlay for holdings and asset detail pages.

It is intentionally implemented as a separate layer and does **not** replace or modify the existing market data provider interface.

## What it adds

- a new `market_sentiment` table + model keyed by symbol
- an `AdanosMarketSentimentService` with a fixed Adanos API base URL
- a `refresh:market-sentiment` Artisan command
- optional `market_sentiment` data on holding and market-data API responses
- an optional sentiment card on the holding detail page
- config and `.env.example` entries for enabling and tuning refresh cadence

## Why this approach

Investbrain's `MarketDataInterface` is clearly designed for quotes, price history, dividends, splits, and related fallback providers. Adanos sentiment data fits better as a separate insight layer rather than a market data provider replacement.

This keeps the integration semantically clean and avoids coupling sentiment refreshes to quote refresh timestamps.

## Optional by design

The integration is fully fail-open:

- if `ADANOS_API_KEY` is not configured, no requests are sent
- API responses continue to work without a `market_sentiment` field
- the holding page does not render the sentiment card
- the scheduler skips the refresh command entirely

## Configuration

```env
ADANOS_API_KEY=
ADANOS_MARKET_SENTIMENT_REFRESH=360
ADANOS_MARKET_SENTIMENT_DAYS=7
ADANOS_MARKET_SENTIMENT_SOURCES=reddit,x,news,polymarket
```

## Validation

Targeted Laravel tests:

```bash
php artisan test --compact tests/MarketSentimentTest.php tests/Api/MarketDataTest.php tests/Api/HoldingsTest.php tests/HoldingsTest.php
```

These cover:
- sentiment fetch + persistence
- database cache reuse
- API serialization when enabled
- explicit omission when disabled
- holding page rendering when enabled
- holding page omission when disabled

## Notes

- Base URL is fixed inside the service and is not user-configurable
- sentiment refresh cadence is separate from the normal market data refresh cadence
- this PR does not touch the existing provider fallback mechanism
